### PR TITLE
feat: Allow setting the "searchParams" property

### DIFF
--- a/lib/immurl.ts
+++ b/lib/immurl.ts
@@ -73,7 +73,13 @@ export class ImmutableURL implements Readonly<URL> {
   ): ImmutableURL {
     const newUrl = new URL(this.toString());
 
-    newUrl[property] = newValue;
+    if (property === 'searchParams') {
+      // searchParams is a readonly property of URL, but we allow to set it anyway for ergonomics reasons
+      // We do this by setting the "search" property as the stringified URLSearchParams.
+      newUrl.search = (newValue as URLSearchParams).toString();
+    } else {
+      newUrl[property] = newValue;
+    }
 
     return new ImmutableURL(newUrl);
   }

--- a/tests/ImmutableURL.test.ts
+++ b/tests/ImmutableURL.test.ts
@@ -55,3 +55,19 @@ test('searchParams property is an ImmutableURLSearchParams', () => {
 
   expect(url.searchParams).toBeInstanceOf(ImmutableURLSearchParams);
 });
+
+test('can update searchParams', () => {
+  const url = new ImmutableURL('https://example.com');
+  const newUrl = url.set(
+    'search',
+    url.searchParams
+      .append('q', 'search-term')
+      .set('foo', 'fuz')
+      .sort()
+      .toString()
+  );
+
+  expect(newUrl.toString()).toEqual(
+    'https://example.com/?foo=fuz&q=search-term'
+  );
+});


### PR DESCRIPTION
Right now the following code throws an error:

```javascript
const newParams = url.searchParams
  .set('foo', 'fuz')
  .sort();

const newUrl = url.set('searchParams', newParams)
```

With an error stating that "searchParams is readonly". This is the case in the spec however in the context of this library it's really quite annoying to work with.

I think allowing this pattern makes sense, even if it diverges slightly from the spec.

The only alternative that sticks to the spec would be something like this (which works in the current version of immurl):

```javascript
const newParams = url.searchParams
  .set('foo', 'fuz')
  .sort();

const newUrl = url.set('search', newParams.toString())
// or rely on implicit string casting
const newUrl = url.set('search', newParams)
```

Note we are getting `searchParams` but setting `search`, because of this we have to either manually stringify or rely on implicit casting (both work, the latter may be less performant and isn't allowrd in TypeScript).

The idea of getting one property and then setting it on another is another caveat that I think you shouldn't have to remember when working with this library, even if it kinda goes against the URL spec.